### PR TITLE
Add "on-the-fly" compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install via [Composer](http://getcomposer.org/), use the command below, it wi
 composer require christoph-kluge/reactphp-http-response-compression-middleware
 ```
 
-This middleware will detect if the request is compressible and will compress the response body and add relevant headers to it. Heavy lifting is done by (clue/php-zlib-react)[https://github.com/clue/php-zlib-react], thanks!
+This middleware will detect if the request is compressible and will compress the response body and add relevant headers to it. Heavy lifting is done by [clue/php-zlib-react](https://github.com/clue/php-zlib-react), thanks!
 
 # Usage
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install via [Composer](http://getcomposer.org/), use the command below, it wi
 composer require christoph-kluge/reactphp-http-response-compression-middleware
 ```
 
-This middleware will detect if the request is compressible and will compress the response body and add relevant headers to it.
+This middleware will detect if the request is compressible and will compress the response body and add relevant headers to it. Heavy lifting is done by (clue/php-zlib-react)[https://github.com/clue/php-zlib-react], thanks!
 
 # Usage
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "php": ">=5.6.0",
         "psr/http-message": "^1.0",
-        "react/promise": "^2.5"
+        "react/promise": "^2.5",
+        "clue/zlib-react": "^0.2"
     },
    "require-dev": {
         "phpunit/phpunit": "^4.8.10||^5.0",

--- a/examples/01-server-with-compression.php
+++ b/examples/01-server-with-compression.php
@@ -15,8 +15,8 @@ $loop = Factory::create();
 
 $server = new Server(new MiddlewareRunner([
     new ResponseCompressionMiddleware([
-        new CompressionGzipHandler(),
-        new CompressionDeflateHandler(),
+        new CompressionGzipHandler($loop),
+        new CompressionDeflateHandler($loop),
     ]),
     function (ServerRequestInterface $request, callable $next) {
         return new Response(200, ['Content-Type' => 'application/json'], json_encode([

--- a/src/CompressionDeflateHandler.php
+++ b/src/CompressionDeflateHandler.php
@@ -5,26 +5,16 @@ namespace Sikei\React\Http\Middleware;
 use Clue\React\Zlib\ZlibFilterStream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
-use React\EventLoop\LoopInterface;
 use React\Http\HttpBodyStream;
-use React\Stream\ReadableResourceStream;
-use React\Stream\ThroughStream;
 
 class CompressionDeflateHandler implements CompressionHandlerInterface
 {
-
-    protected $loop;
-
-    public function __construct(LoopInterface $loop)
-    {
-        $this->loop = $loop;
-    }
 
     public function compressible(ServerRequestInterface $request)
     {
         $accept = $request->getHeaderLine('Accept-Encoding');
 
-        return stristr($accept, 'deflate') !== false;
+        return stristr($accept, $this->__toString()) !== false;
     }
 
     public function __toString()
@@ -38,13 +28,14 @@ class CompressionDeflateHandler implements CompressionHandlerInterface
             return $body;
         }
 
-        $in = new ReadableResourceStream($body->detach(), $this->loop);
-        $out = new ThroughStream();
+        if ($body instanceof HttpBodyStream) {
+            return new HttpBodyStream($body->pipe(
+                ZlibFilterStream::createDeflateCompressor(1)
+            ), null);
+        }
 
-        $compressor = ZlibFilterStream::createDeflateCompressor(1);
-
-        $in->pipe($compressor)->pipe($out);
-
-        return new HttpBodyStream($out, null);
+        return \RingCentral\Psr7\stream_for(
+            gzencode($body->getContents(), -1, FORCE_DEFLATE)
+        );
     }
 }

--- a/src/CompressionDeflateHandler.php
+++ b/src/CompressionDeflateHandler.php
@@ -2,12 +2,23 @@
 
 namespace Sikei\React\Http\Middleware;
 
+use Clue\React\Zlib\ZlibFilterStream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
+use React\EventLoop\LoopInterface;
 use React\Http\HttpBodyStream;
+use React\Stream\ReadableResourceStream;
+use React\Stream\ThroughStream;
 
 class CompressionDeflateHandler implements CompressionHandlerInterface
 {
+
+    protected $loop;
+
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
 
     public function compressible(ServerRequestInterface $request)
     {
@@ -21,19 +32,19 @@ class CompressionDeflateHandler implements CompressionHandlerInterface
         return 'deflate';
     }
 
-    public function __invoke(StreamInterface $stream, $mime)
+    public function __invoke(StreamInterface $body, $mime)
     {
-        if (!$stream->isWritable()) {
-            return $stream;
+        if (!$body->isReadable()) {
+            return $body;
         }
 
-        if ($stream instanceof HttpBodyStream) {
-            return $stream;
-        }
+        $in = new ReadableResourceStream($body->detach(), $this->loop);
+        $out = new ThroughStream();
 
-        $content = $stream->getContents();
-        $content = gzencode($content, -1, FORCE_DEFLATE);
+        $compressor = ZlibFilterStream::createDeflateCompressor(1);
 
-        return \RingCentral\Psr7\stream_for($content);
+        $in->pipe($compressor)->pipe($out);
+
+        return new HttpBodyStream($out, null);
     }
 }

--- a/src/CompressionDeflateHandler.php
+++ b/src/CompressionDeflateHandler.php
@@ -6,6 +6,7 @@ use Clue\React\Zlib\ZlibFilterStream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use React\Http\HttpBodyStream;
+use React\Stream\ReadableStreamInterface;
 
 class CompressionDeflateHandler implements CompressionHandlerInterface
 {
@@ -24,11 +25,7 @@ class CompressionDeflateHandler implements CompressionHandlerInterface
 
     public function __invoke(StreamInterface $body, $mime)
     {
-        if (!$body->isReadable()) {
-            return $body;
-        }
-
-        if ($body instanceof HttpBodyStream) {
+        if ($body instanceof ReadableStreamInterface) {
             return new HttpBodyStream($body->pipe(
                 ZlibFilterStream::createDeflateCompressor(1)
             ), null);

--- a/src/CompressionGzipHandler.php
+++ b/src/CompressionGzipHandler.php
@@ -5,26 +5,16 @@ namespace Sikei\React\Http\Middleware;
 use Clue\React\Zlib\ZlibFilterStream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
-use React\EventLoop\LoopInterface;
 use React\Http\HttpBodyStream;
-use React\Stream\ReadableResourceStream;
-use React\Stream\ThroughStream;
 
 class CompressionGzipHandler implements CompressionHandlerInterface
 {
-
-    protected $loop;
-
-    public function __construct(LoopInterface $loop)
-    {
-        $this->loop = $loop;
-    }
 
     public function compressible(ServerRequestInterface $request)
     {
         $accept = $request->getHeaderLine('Accept-Encoding');
 
-        return stristr($accept, 'gzip') !== false;
+        return stristr($accept, $this->__toString()) !== false;
     }
 
     public function __toString()
@@ -38,13 +28,14 @@ class CompressionGzipHandler implements CompressionHandlerInterface
             return $body;
         }
 
-        $in = new ReadableResourceStream($body->detach(), $this->loop);
-        $out = new ThroughStream();
+        if ($body instanceof HttpBodyStream) {
+            return new HttpBodyStream($body->pipe(
+                ZlibFilterStream::createGzipCompressor(1)
+            ), null);
+        }
 
-        $compressor = ZlibFilterStream::createGzipCompressor(1);
-
-        $in->pipe($compressor)->pipe($out);
-
-        return new HttpBodyStream($out, null);
+        return \RingCentral\Psr7\stream_for(
+            gzencode($body->getContents(), -1, FORCE_GZIP)
+        );
     }
 }

--- a/src/CompressionGzipHandler.php
+++ b/src/CompressionGzipHandler.php
@@ -6,6 +6,7 @@ use Clue\React\Zlib\ZlibFilterStream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use React\Http\HttpBodyStream;
+use React\Stream\ReadableStreamInterface;
 
 class CompressionGzipHandler implements CompressionHandlerInterface
 {
@@ -24,11 +25,7 @@ class CompressionGzipHandler implements CompressionHandlerInterface
 
     public function __invoke(StreamInterface $body, $mime)
     {
-        if (!$body->isReadable()) {
-            return $body;
-        }
-
-        if ($body instanceof HttpBodyStream) {
+        if ($body instanceof ReadableStreamInterface) {
             return new HttpBodyStream($body->pipe(
                 ZlibFilterStream::createGzipCompressor(1)
             ), null);

--- a/src/CompressionHandlerInterface.php
+++ b/src/CompressionHandlerInterface.php
@@ -9,13 +9,15 @@ interface CompressionHandlerInterface
 {
 
     /**
+     * Should check if the request is compressible
      * @param ServerRequestInterface $request
      * @return boolean
      */
     public function compressible(ServerRequestInterface $request);
 
     /**
-     * Return the compression delegate token name (i.e. gzip, deflate, br, ...)
+     * Return the compression coding token (i.e. gzip, deflate, br, ...)
+     * @see https://tools.ietf.org/html/rfc7230#section-4.2
      * @return string
      */
     public function __toString();

--- a/tests/CompressionDeflateHandlerTest.php
+++ b/tests/CompressionDeflateHandlerTest.php
@@ -56,7 +56,7 @@ class CompressionDeflateHandlerTest extends TestCase
             $compressBuffer .= $data;
         });
 
-        $this->assertInstanceOf('React\Http\HttpBodyStream', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
         $decompressor = ZlibFilterStream::createDeflateDecompressor();
         $decompressor->on('data', function ($data) use (&$decompressBuffer) {

--- a/tests/CompressionDeflateHandlerTest.php
+++ b/tests/CompressionDeflateHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Sikei\React\Http\Middleware;
+
+use Clue\React\Zlib\ZlibFilterStream;
+use PHPUnit\Framework\TestCase;
+use React\Http\HttpBodyStream;
+use React\Http\ServerRequest;
+use React\Stream\ThroughStream;
+use function RingCentral\Psr7\stream_for;
+
+class CompressionDeflateHandlerTest extends TestCase
+{
+
+    /** @var CompressionGzipHandler */
+    public $handler;
+
+    public function setUp()
+    {
+        $this->handler = new CompressionDeflateHandler();
+    }
+
+    public function testHandlerHasCorrectToken()
+    {
+        $this->assertSame('deflate', (string)$this->handler);
+    }
+
+    public function testHandlerCanHandleClientCompressionMethods()
+    {
+        $request = new ServerRequest('GET', 'https://example.com/', [
+            'Accept-Encoding' => 'deflate',
+        ]);
+
+        $this->assertTrue($this->handler->compressible($request));
+    }
+
+    public function testHandlerCannotHandleClientsCompressionMethods()
+    {
+        $request = new ServerRequest('GET', 'https://example.com/', [
+            'Accept-Encoding' => 'some-other',
+        ]);
+
+        $this->assertFalse($this->handler->compressible($request));
+    }
+
+    public function testHandlerWillCompressHttpBodyStream()
+    {
+        $content = 'My test string';
+
+        $stream = new ThroughStream();
+        $body = new HttpBodyStream($stream, null);
+        $body = $this->handler->__invoke($body, 'application/text');
+
+        $body->on('data', function ($data) use (&$compressBuffer) {
+            $compressBuffer .= $data;
+        });
+
+        $this->assertInstanceOf('React\Http\HttpBodyStream', $body);
+
+        $decompressor = ZlibFilterStream::createDeflateDecompressor();
+        $decompressor->on('data', function ($data) use (&$decompressBuffer) {
+            $decompressBuffer .= $data;
+        });
+
+        $body->pipe($decompressor);
+
+        $stream->write($content);
+        $stream->end();
+
+        $this->assertNotSame($content, $compressBuffer);
+        $this->assertSame($content, $decompressBuffer);
+    }
+
+    public function testHandlerWillCompressNonHttpBodyStream()
+    {
+        $content = 'My test string';
+
+        $body = stream_for($content);
+        $body = $this->handler->__invoke($body, 'application/text');
+
+        $this->assertInstanceOf('RingCentral\Psr7\Stream', $body);
+        $compressed = $body->getContents();
+        $this->assertSame($content, zlib_decode($compressed, strlen($compressed)));
+    }
+}

--- a/tests/CompressionDeflateHandlerTest.php
+++ b/tests/CompressionDeflateHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sikei\React\Http\Middleware;
+namespace Sikei\React\Tests\Http\Middleware;
 
 use Clue\React\Zlib\ZlibFilterStream;
 use PHPUnit\Framework\TestCase;
@@ -8,11 +8,12 @@ use React\Http\HttpBodyStream;
 use React\Http\ServerRequest;
 use React\Stream\ThroughStream;
 use function RingCentral\Psr7\stream_for;
+use Sikei\React\Http\Middleware\CompressionDeflateHandler;
 
 class CompressionDeflateHandlerTest extends TestCase
 {
 
-    /** @var CompressionGzipHandler */
+    /** @var CompressionDeflateHandler */
     public $handler;
 
     public function setUp()

--- a/tests/CompressionGzipHandlerTest.php
+++ b/tests/CompressionGzipHandlerTest.php
@@ -56,7 +56,7 @@ class CompressionGzipHandlerTest extends TestCase
             $compressBuffer .= $data;
         });
 
-        $this->assertInstanceOf('React\Http\HttpBodyStream', $body);
+        $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $body);
 
         $decompressor = ZlibFilterStream::createGzipDecompressor();
         $decompressor->on('data', function ($data) use (&$decompressBuffer) {

--- a/tests/CompressionGzipHandlerTest.php
+++ b/tests/CompressionGzipHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Sikei\React\Http\Middleware;
+
+use Clue\React\Zlib\ZlibFilterStream;
+use PHPUnit\Framework\TestCase;
+use React\Http\HttpBodyStream;
+use React\Http\ServerRequest;
+use React\Stream\ThroughStream;
+use function RingCentral\Psr7\stream_for;
+
+class CompressionGzipHandlerTest extends TestCase
+{
+
+    /** @var CompressionGzipHandler */
+    public $handler;
+
+    public function setUp()
+    {
+        $this->handler = new CompressionGzipHandler();
+    }
+
+    public function testHandlerHasCorrectToken()
+    {
+        $this->assertSame('gzip', (string)$this->handler);
+    }
+
+    public function testHandlerCanHandleClientCompressionMethods()
+    {
+        $request = new ServerRequest('GET', 'https://example.com/', [
+            'Accept-Encoding' => 'gzip',
+        ]);
+
+        $this->assertTrue($this->handler->compressible($request));
+    }
+
+    public function testHandlerCannotHandleClientsCompressionMethods()
+    {
+        $request = new ServerRequest('GET', 'https://example.com/', [
+            'Accept-Encoding' => 'some-other',
+        ]);
+
+        $this->assertFalse($this->handler->compressible($request));
+    }
+
+    public function testHandlerWillCompressHttpBodyStream()
+    {
+        $content = 'My test string';
+
+        $stream = new ThroughStream();
+        $body = new HttpBodyStream($stream, null);
+        $body = $this->handler->__invoke($body, 'application/text');
+
+        $body->on('data', function ($data) use (&$compressBuffer) {
+            $compressBuffer .= $data;
+        });
+
+        $this->assertInstanceOf('React\Http\HttpBodyStream', $body);
+
+        $decompressor = ZlibFilterStream::createGzipDecompressor();
+        $decompressor->on('data', function ($data) use (&$decompressBuffer) {
+            $decompressBuffer .= $data;
+        });
+
+        $body->pipe($decompressor);
+
+        $stream->write($content);
+        $stream->end();
+
+        $this->assertNotSame($content, $compressBuffer);
+        $this->assertSame($content, $decompressBuffer);
+    }
+
+    public function testHandlerWillCompressNonHttpBodyStream()
+    {
+        $content = 'My test string';
+
+        $body = stream_for($content);
+        $body = $this->handler->__invoke($body, 'application/text');
+
+        $this->assertInstanceOf('RingCentral\Psr7\Stream', $body);
+        $compressed = $body->getContents();
+        $this->assertSame($content, zlib_decode($compressed, strlen($compressed)));
+    }
+}

--- a/tests/CompressionGzipHandlerTest.php
+++ b/tests/CompressionGzipHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Sikei\React\Http\Middleware;
+namespace Sikei\React\Tests\Http\Middleware;
 
 use Clue\React\Zlib\ZlibFilterStream;
 use PHPUnit\Framework\TestCase;
@@ -8,6 +8,7 @@ use React\Http\HttpBodyStream;
 use React\Http\ServerRequest;
 use React\Stream\ThroughStream;
 use function RingCentral\Psr7\stream_for;
+use Sikei\React\Http\Middleware\CompressionGzipHandler;
 
 class CompressionGzipHandlerTest extends TestCase
 {

--- a/tests/CompressionHandlerStub.php
+++ b/tests/CompressionHandlerStub.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sikei\React\Tests\Http\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use function RingCentral\Psr7\stream_for;
+use Sikei\React\Http\Middleware\CompressionHandlerInterface;
+
+class CompressionHandlerStub implements CompressionHandlerInterface
+{
+
+    protected $token;
+    protected $response;
+
+    public function __construct($token, $response)
+    {
+        $this->token = $token;
+        $this->response = $response;
+    }
+
+    public function compressible(ServerRequestInterface $request)
+    {
+        return stristr($request->getHeaderLine('Accept-Encoding'), (string)$this) !== false;
+    }
+
+    public function __toString()
+    {
+        return $this->token;
+    }
+
+    public function __invoke(StreamInterface $stream, $mime)
+    {
+        return stream_for($this->response);
+    }
+}

--- a/tests/ResponseCompressionMiddlewareTest.php
+++ b/tests/ResponseCompressionMiddlewareTest.php
@@ -34,6 +34,8 @@ class ResponseCompressionMiddlewareTest extends TestCase
 
     public function testCompressWhenGzipHeadersArePresent()
     {
+        $this->markTestSkipped('This should implement a stub and move specific handler into own tests');
+
         $content = 'Some response';
         $request = new ServerRequest('GET', 'https://example.com/', ['Accept-Encoding' => 'gzip, deflate, br']);
         $response = new Response(200, [

--- a/tests/ResponseCompressionMiddlewareTest.php
+++ b/tests/ResponseCompressionMiddlewareTest.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace Sikei\React\Http\Middleware;
+namespace Sikei\React\Tests\Http\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\StreamInterface;
 use React\Http\Response;
 use React\Http\ServerRequest;
 use React\Promise\Promise;
 use React\Promise\PromiseInterface;
-use function RingCentral\Psr7\stream_for;
+use Sikei\React\Http\Middleware\ResponseCompressionMiddleware;
 
 class ResponseCompressionMiddlewareTest extends TestCase
 {
@@ -47,7 +46,7 @@ class ResponseCompressionMiddlewareTest extends TestCase
         $token = 'custom';
         $return = 'compressed';
         $middleware = new ResponseCompressionMiddleware([
-            $this->getCustomCompressionHandler($token, $return),
+            new CompressionHandlerStub($token, $return)
         ]);
 
         /** @var PromiseInterface $result */
@@ -75,7 +74,7 @@ class ResponseCompressionMiddlewareTest extends TestCase
         $token = 'custom';
         $return = 'compressed';
         $middleware = new ResponseCompressionMiddleware([
-            $this->getCustomCompressionHandler($token, $return),
+            new CompressionHandlerStub($token, $return)
         ]);
 
         /** @var PromiseInterface $result */
@@ -142,37 +141,6 @@ class ResponseCompressionMiddlewareTest extends TestCase
             return new Promise(function ($resolve, $reject) use ($request, &$response) {
                 return $resolve($response);
             });
-        };
-    }
-
-    public function getCustomCompressionHandler($token, $invoke)
-    {
-        return new class ($token, $invoke) implements CompressionHandlerInterface
-        {
-
-            protected $token;
-            protected $response;
-
-            public function __construct($token, $response)
-            {
-                $this->token = $token;
-                $this->response = $response;
-            }
-
-            public function compressible(ServerRequestInterface $request)
-            {
-                return stristr($request->getHeaderLine('Accept-Encoding'), (string)$this) !== false;
-            }
-
-            public function __toString()
-            {
-                return $this->token;
-            }
-
-            public function __invoke(StreamInterface $stream, $mime)
-            {
-                return stream_for($this->response);
-            }
         };
     }
 

--- a/tests/ResponseCompressionMiddlewareTest.php
+++ b/tests/ResponseCompressionMiddlewareTest.php
@@ -47,7 +47,7 @@ class ResponseCompressionMiddlewareTest extends TestCase
         $token = 'custom';
         $return = 'compressed';
         $middleware = new ResponseCompressionMiddleware([
-            $this->getCustomCompressionHandler($token, $return)
+            $this->getCustomCompressionHandler($token, $return),
         ]);
 
         /** @var PromiseInterface $result */
@@ -72,11 +72,10 @@ class ResponseCompressionMiddlewareTest extends TestCase
             'Content-Length' => strlen($content),
         ], $content);
 
-
         $token = 'custom';
         $return = 'compressed';
         $middleware = new ResponseCompressionMiddleware([
-            $this->getCustomCompressionHandler($token, $return)
+            $this->getCustomCompressionHandler($token, $return),
         ]);
 
         /** @var PromiseInterface $result */


### PR DESCRIPTION
This PR aims to solve #2. After a lot of reading and understanding of the React\Http\Server and some articles like [phpreact-streams](http://seregazhuk.github.io/2017/06/12/phpreact-streams/). I finally managed to get the work done. 

Additional notes: 
* The final `Response` will now contain the `Transfer-Encoding: chunked` header
* Some browser tests showed that there is a split now in `TTFB` and `Content-Download`
* Tested in latest versions of Chrome, Safari and Firefox
* Marked specific gzip test as skipped as it's not part of the Middleware and should be replaced by a stub. I will file that later