### PR TITLE
Added default response compression detectors (array and regex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,54 @@ $server = new Server(new MiddlewareRunner([
 ]));
 ```
 
+# Response-detection for compressible mime/content-types
+
+## Default detection
+
+The default handlers will use by default the `DefaultRegexDetecor` to identify compressible Content-Types by a set of regular expressions. Those regular expressions are:
+
+```php
+// DefaultRegexDetector.php -> used in __construct()
+
+new RegexDetector([
+    '/^text\/[a-z-\+]+$/', // text/*
+    '/^application\/json$/', // application/json
+    '/^application\/xml$/', // application/xml
+    '/^[a-z-\+]+\/[a-z-\+]+\+json$/', // */*+json
+    '/^[a-z-\+]+\/[a-z-\+]+\+xml$/', // */*+xml
+]);
+```
+
+## Available Detectors
+
+There are currently the following available detectors:
+
+* `ArrayDetector`: Which will accept an whitelist of mime-types to check against
+* `RegexDetecor`: Which will accept an whitelist of regular expressions to check against
+
+```php
+new CompressionGzipHandler(new ArrayDetector[
+    'text/html',
+]),
+new CompressionGzipHandler(new RegexDetector[
+    '/^text\/[a-z]+$/',
+]),
+```
+
+## Want ot implement custom detectors?
+
+If you would like to add a custom detection for the response mime type then you can simply pass an object as first parameter which implements the `MimeDetectorInterface`.
+
+```php
+new CompressionGzipHandler(new class implements MimeDetectorInterface {
+    public function isCompressible($mime) {
+        // your custom magic here..
+        return true;
+    }
+}),
+
+```
+
 # License
 
 The MIT License (MIT)

--- a/src/CompressionDeflateHandler.php
+++ b/src/CompressionDeflateHandler.php
@@ -11,11 +11,16 @@ use React\Stream\ReadableStreamInterface;
 class CompressionDeflateHandler implements CompressionHandlerInterface
 {
 
-    public function compressible(ServerRequestInterface $request)
+    public function canHandle(ServerRequestInterface $request)
     {
         $accept = $request->getHeaderLine('Accept-Encoding');
 
         return stristr($accept, $this->__toString()) !== false;
+    }
+
+    public function isCompressible($mime)
+    {
+        return true;
     }
 
     public function __toString()
@@ -23,7 +28,7 @@ class CompressionDeflateHandler implements CompressionHandlerInterface
         return 'deflate';
     }
 
-    public function __invoke(StreamInterface $body, $mime)
+    public function __invoke(StreamInterface $body)
     {
         if ($body instanceof ReadableStreamInterface) {
             return new HttpBodyStream($body->pipe(

--- a/src/CompressionDeflateHandler.php
+++ b/src/CompressionDeflateHandler.php
@@ -7,9 +7,18 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use React\Http\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
+use Sikei\React\Http\Middleware\Detector\DefaultRegexDetector;
+use Sikei\React\Http\Middleware\Detector\RegexDetector;
 
 class CompressionDeflateHandler implements CompressionHandlerInterface
 {
+
+    protected $detector;
+
+    public function __construct(MimeDetectorInterface $detector = null)
+    {
+        $this->detector = $detector ?: new DefaultRegexDetector();
+    }
 
     public function canHandle(ServerRequestInterface $request)
     {
@@ -20,7 +29,7 @@ class CompressionDeflateHandler implements CompressionHandlerInterface
 
     public function isCompressible($mime)
     {
-        return true;
+        return $this->detector->isCompressible($mime);
     }
 
     public function __toString()

--- a/src/CompressionGzipHandler.php
+++ b/src/CompressionGzipHandler.php
@@ -7,9 +7,17 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use React\Http\HttpBodyStream;
 use React\Stream\ReadableStreamInterface;
+use Sikei\React\Http\Middleware\Detector\DefaultRegexDetector;
 
 class CompressionGzipHandler implements CompressionHandlerInterface
 {
+
+    protected $detector;
+
+    public function __construct(MimeDetectorInterface $detector = null)
+    {
+        $this->detector = $detector ?: new DefaultRegexDetector();
+    }
 
     public function canHandle(ServerRequestInterface $request)
     {
@@ -20,7 +28,7 @@ class CompressionGzipHandler implements CompressionHandlerInterface
 
     public function isCompressible($mime)
     {
-        return true;
+        return $this->detector->isCompressible($mime);
     }
 
     public function __toString()

--- a/src/CompressionGzipHandler.php
+++ b/src/CompressionGzipHandler.php
@@ -11,11 +11,16 @@ use React\Stream\ReadableStreamInterface;
 class CompressionGzipHandler implements CompressionHandlerInterface
 {
 
-    public function compressible(ServerRequestInterface $request)
+    public function canHandle(ServerRequestInterface $request)
     {
         $accept = $request->getHeaderLine('Accept-Encoding');
 
         return stristr($accept, $this->__toString()) !== false;
+    }
+
+    public function isCompressible($mime)
+    {
+        return true;
     }
 
     public function __toString()
@@ -23,7 +28,7 @@ class CompressionGzipHandler implements CompressionHandlerInterface
         return 'gzip';
     }
 
-    public function __invoke(StreamInterface $body, $mime)
+    public function __invoke(StreamInterface $body)
     {
         if ($body instanceof ReadableStreamInterface) {
             return new HttpBodyStream($body->pipe(

--- a/src/CompressionHandlerInterface.php
+++ b/src/CompressionHandlerInterface.php
@@ -9,11 +9,18 @@ interface CompressionHandlerInterface
 {
 
     /**
-     * Should check if the request is compressible
+     * Check if the request can be handled by this
      * @param ServerRequestInterface $request
      * @return boolean
      */
-    public function compressible(ServerRequestInterface $request);
+    public function canHandle(ServerRequestInterface $request);
+
+    /**
+     * Checks wether a mime-type can be compressed
+     * @param string $mime
+     * @return mixed
+     */
+    public function isCompressible($mime);
 
     /**
      * Return the compression coding token (i.e. gzip, deflate, br, ...)
@@ -25,8 +32,7 @@ interface CompressionHandlerInterface
     /**
      * Invocation should attach an compressor to the stream and return the stream resource
      * @param StreamInterface $stream
-     * @param string          $mime
      * @return StreamInterface
      */
-    public function __invoke(StreamInterface $stream, $mime);
+    public function __invoke(StreamInterface $stream);
 }

--- a/src/Detector/ArrayDetector.php
+++ b/src/Detector/ArrayDetector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sikei\React\Http\Middleware\Detector;
+
+use Sikei\React\Http\Middleware\MimeDetectorInterface;
+
+class ArrayDetector implements MimeDetectorInterface
+{
+
+    protected $mimes;
+
+    public function __construct(array $mimes)
+    {
+        $this->mimes = array_filter($mimes, function ($val) {
+            return is_string($val);
+        });
+    }
+
+    /**
+     * Checks wether a mime-type can be compressed
+     * @param string $mime
+     * @return mixed
+     */
+    public function isCompressible($mime)
+    {
+        return in_array($mime, $this->mimes);
+    }
+}

--- a/src/Detector/DefaultRegexDetector.php
+++ b/src/Detector/DefaultRegexDetector.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sikei\React\Http\Middleware\Detector;
+
+use Sikei\React\Http\Middleware\MimeDetectorInterface;
+
+class DefaultRegexDetector implements MimeDetectorInterface
+{
+
+    protected $detector;
+
+    public function __construct()
+    {
+        $this->detector = new RegexDetector([
+            '/^text\/[a-z-\+]+$/', // text/*
+            '/^application\/json$/', // application/json
+            '/^application\/xml$/', // application/xml
+            '/^[a-z-\+]+\/[a-z-\+]+\+json$/', // */*+json
+            '/^[a-z-\+]+\/[a-z-\+]+\+xml$/', // */*+xml
+        ]);
+    }
+
+    /**
+     * Checks wether a mime-type can be compressed
+     * @param string $mime
+     * @return mixed
+     */
+    public function isCompressible($mime)
+    {
+        return $this->detector->isCompressible($mime);
+    }
+}

--- a/src/Detector/RegexDetector.php
+++ b/src/Detector/RegexDetector.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sikei\React\Http\Middleware\Detector;
+
+use Sikei\React\Http\Middleware\MimeDetectorInterface;
+
+class RegexDetector implements MimeDetectorInterface
+{
+
+    protected $expressions;
+
+    public function __construct(array $expressions)
+    {
+        $this->expressions = $expressions;
+    }
+
+    /**
+     * Checks wether a mime-type can be compressed
+     * @param string $mime
+     * @return mixed
+     */
+    public function isCompressible($mime)
+    {
+        foreach ($this->expressions as $regex) {
+            try {
+                if (preg_match($regex, $mime)) {
+                    return true;
+                }
+            } catch (\Exception $exception) {
+
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/MimeDetectorInterface.php
+++ b/src/MimeDetectorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sikei\React\Http\Middleware;
+
+interface MimeDetectorInterface
+{
+
+    /**
+     * Checks wether a mime-type can be compressed
+     * @param string $mime
+     * @return mixed
+     */
+    public function isCompressible($mime);
+}

--- a/src/ResponseCompressionMiddleware.php
+++ b/src/ResponseCompressionMiddleware.php
@@ -52,18 +52,23 @@ final class ResponseCompressionMiddleware
             if (!$response->hasHeader('Content-Type')) {
                 return $response;
             }
+
+            // response mime-type is not compressible
             $mime = $response->getHeaderLine('Content-Type');
+            if (!$compressor->isCompressible($mime)) {
+                return $response;
+            }
 
             return $response
                 ->withHeader('Content-Encoding', (string)$compressor)
-                ->withBody($compressor($response->getBody(), $mime));
+                ->withBody($compressor($response->getBody()));
         });
     }
 
     private function getCompressor(ServerRequestInterface $request)
     {
         foreach ($this->compressors as $compressor) {
-            if ($compressor->compressible($request)) {
+            if ($compressor->canHandle($request)) {
                 return $compressor;
             }
         }

--- a/tests/CompressionDeflateHandlerTest.php
+++ b/tests/CompressionDeflateHandlerTest.php
@@ -32,7 +32,7 @@ class CompressionDeflateHandlerTest extends TestCase
             'Accept-Encoding' => 'deflate',
         ]);
 
-        $this->assertTrue($this->handler->compressible($request));
+        $this->assertTrue($this->handler->canHandle($request));
     }
 
     public function testHandlerCannotHandleClientsCompressionMethods()
@@ -41,7 +41,7 @@ class CompressionDeflateHandlerTest extends TestCase
             'Accept-Encoding' => 'some-other',
         ]);
 
-        $this->assertFalse($this->handler->compressible($request));
+        $this->assertFalse($this->handler->canHandle($request));
     }
 
     public function testHandlerWillCompressHttpBodyStream()
@@ -50,7 +50,7 @@ class CompressionDeflateHandlerTest extends TestCase
 
         $stream = new ThroughStream();
         $body = new HttpBodyStream($stream, null);
-        $body = $this->handler->__invoke($body, 'application/text');
+        $body = $this->handler->__invoke($body);
 
         $body->on('data', function ($data) use (&$compressBuffer) {
             $compressBuffer .= $data;
@@ -77,7 +77,7 @@ class CompressionDeflateHandlerTest extends TestCase
         $content = 'My test string';
 
         $body = stream_for($content);
-        $body = $this->handler->__invoke($body, 'application/text');
+        $body = $this->handler->__invoke($body);
 
         $this->assertInstanceOf('RingCentral\Psr7\Stream', $body);
         $compressed = $body->getContents();

--- a/tests/CompressionGzipHandlerTest.php
+++ b/tests/CompressionGzipHandlerTest.php
@@ -32,7 +32,7 @@ class CompressionGzipHandlerTest extends TestCase
             'Accept-Encoding' => 'gzip',
         ]);
 
-        $this->assertTrue($this->handler->compressible($request));
+        $this->assertTrue($this->handler->canHandle($request));
     }
 
     public function testHandlerCannotHandleClientsCompressionMethods()
@@ -41,7 +41,7 @@ class CompressionGzipHandlerTest extends TestCase
             'Accept-Encoding' => 'some-other',
         ]);
 
-        $this->assertFalse($this->handler->compressible($request));
+        $this->assertFalse($this->handler->canHandle($request));
     }
 
     public function testHandlerWillCompressHttpBodyStream()

--- a/tests/CompressionHandlerStub.php
+++ b/tests/CompressionHandlerStub.php
@@ -12,14 +12,21 @@ class CompressionHandlerStub implements CompressionHandlerInterface
 
     protected $token;
     protected $response;
+    protected $compressible;
 
-    public function __construct($token, $response)
+    public function __construct($token, $response, $compressible)
     {
         $this->token = $token;
         $this->response = $response;
+        $this->compressible = $compressible;
     }
 
-    public function compressible(ServerRequestInterface $request)
+    public function isCompressible($mime)
+    {
+        return (bool)$this->compressible;
+    }
+
+    public function canHandle(ServerRequestInterface $request)
     {
         return stristr($request->getHeaderLine('Accept-Encoding'), (string)$this) !== false;
     }
@@ -29,7 +36,7 @@ class CompressionHandlerStub implements CompressionHandlerInterface
         return $this->token;
     }
 
-    public function __invoke(StreamInterface $stream, $mime)
+    public function __invoke(StreamInterface $stream)
     {
         return stream_for($this->response);
     }

--- a/tests/Detector/ArrayDetectorTest.php
+++ b/tests/Detector/ArrayDetectorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Sikei\React\Tests\Http\Middleware\Detector;
+
+use PHPUnit\Framework\TestCase;
+use Sikei\React\Http\Middleware\Detector\ArrayDetector;
+
+class ArrayDetectorTest extends TestCase
+{
+
+    public function testNothingWillDetectNothing()
+    {
+        $detector = new ArrayDetector([]);
+
+        $this->assertFalse($detector->isCompressible('something'));
+    }
+
+    public function testInvalidArrayValuesExpression()
+    {
+        $detector = new ArrayDetector([
+            0,
+            1,
+            false,
+            true,
+            new \stdClass(),
+        ]);
+
+        $this->assertFalse($detector->isCompressible('a'));
+    }
+
+    public function testInvalidDetection()
+    {
+        $detector = new ArrayDetector(['a', 'c']);
+
+        $this->assertFalse($detector->isCompressible('b'));
+    }
+
+    public function testValidDetection()
+    {
+        $detector = new ArrayDetector(['a', 'c']);
+
+        $this->assertTrue($detector->isCompressible('a'));
+        $this->assertTrue($detector->isCompressible('c'));
+    }
+}

--- a/tests/Detector/DefaultRegexDetectorTest.php
+++ b/tests/Detector/DefaultRegexDetectorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sikei\React\Tests\Http\Middleware\Detector;
+
+use PHPUnit\Framework\TestCase;
+use Sikei\React\Http\Middleware\Detector\DefaultRegexDetector;
+use Sikei\React\Http\Middleware\Detector\RegexDetector;
+
+class DefaultRegexDetectorTest extends TestCase
+{
+
+    public function testDefaultRegexDetection()
+    {
+        $detector = new DefaultRegexDetector();
+
+        $this->assertTrue($detector->isCompressible('text/html'));
+        $this->assertTrue($detector->isCompressible('text/csv'));
+        $this->assertTrue($detector->isCompressible('application/json'));
+        $this->assertTrue($detector->isCompressible('application/xml'));
+        $this->assertTrue($detector->isCompressible('application/calendar+json'));
+        $this->assertTrue($detector->isCompressible('application/rdf+xml'));
+    }
+}

--- a/tests/Detector/RegexDetectorTest.php
+++ b/tests/Detector/RegexDetectorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Sikei\React\Tests\Http\Middleware\Detector;
+
+use PHPUnit\Framework\TestCase;
+use Sikei\React\Http\Middleware\Detector\RegexDetector;
+
+class RegexDetectorTest extends TestCase
+{
+
+    public function testNothingWillDetectNothing()
+    {
+        $detector = new RegexDetector([]);
+
+        $this->assertFalse($detector->isCompressible('something'));
+    }
+
+    public function testInvalidRegularExpression()
+    {
+        $detector = new RegexDetector(['^^$$']);
+
+        $this->assertFalse($detector->isCompressible('a'));
+    }
+
+    public function testInvalidDetection()
+    {
+        $detector = new RegexDetector(['a', 'c']);
+
+        $this->assertFalse($detector->isCompressible('b'));
+    }
+
+    public function testValidSimpleDetection()
+    {
+        $detector = new RegexDetector(['/^text\/html$/']);
+
+        $this->assertTrue($detector->isCompressible('text/html'));
+    }
+
+    public function testValidRegexDetection()
+    {
+        $detector = new RegexDetector(['/^text\/[a-z]+$/']);
+
+        $this->assertTrue($detector->isCompressible('text/html'));
+    }
+}

--- a/tests/ResponseCompressionMiddlewareTest.php
+++ b/tests/ResponseCompressionMiddlewareTest.php
@@ -46,7 +46,7 @@ class ResponseCompressionMiddlewareTest extends TestCase
         $token = 'custom';
         $return = 'compressed';
         $middleware = new ResponseCompressionMiddleware([
-            new CompressionHandlerStub($token, $return)
+            new CompressionHandlerStub($token, $return, true)
         ]);
 
         /** @var PromiseInterface $result */
@@ -74,7 +74,7 @@ class ResponseCompressionMiddlewareTest extends TestCase
         $token = 'custom';
         $return = 'compressed';
         $middleware = new ResponseCompressionMiddleware([
-            new CompressionHandlerStub($token, $return)
+            new CompressionHandlerStub($token, $return, true)
         ]);
 
         /** @var PromiseInterface $result */


### PR DESCRIPTION
While I started to tackle #4  (original: https://github.com/reactphp/http/pull/219#issuecomment-329572412) I came up with the following solution to add a `MimeDetectorInterface` and two Default Detectors `ArrayDetector` and `RegexDetector`. 

I think in a follow-up PR it should be easy to add a `MimeDbDetector`-Wrapper which will fetch the mime-db/load the mime-db and pass the compressible mimes to the `ArrayDetector`.. 

ping @jsor, @WyriHaximus :) 